### PR TITLE
Added Signal user keys for registration + serialization helpers

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,7 @@ const config = {
       },
     ],
     '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
+    '@typescript-eslint/no-non-null-assertion': 'off',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'error',
     'no-var': 'error',

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,11 @@
 /** @type {import("next").NextConfig} */
 const config = {
   reactStrictMode: true,
+  webpack: config => {
+    config.resolve.fallback = { fs: false }
+
+    return config
+  },
 
   /**
    * If you have the "experimental: { appDir: true }" setting enabled, then you

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,8 +25,8 @@ model User {
     recievedMessages Message[] @relation("recipient")
 
     // Prisma sets this as optional, but it is a required 1-1 relation
-    SignedPreKey   SignedPreKey?
-    OneTimePreKeys OneTimePreKey[]
+    signedPreKey   SignedPreKey?
+    oneTimePreKeys OneTimePreKey[]
 
     // Note name and email will NOT be used, but they are fields generally required by next-auth
     // Will be required for any sort of server-side session management
@@ -43,7 +43,7 @@ model User {
 }
 
 model SignedPreKey {
-    id        Int
+    keyId     Int
     publicKey String
     signature String
     userId    String @unique @db.Uuid // unique enforces 1-1 constraint
@@ -55,13 +55,13 @@ model SignedPreKey {
 }
 
 model OneTimePreKey {
-    id        Int
+    keyId     Int
     publicKey String
     userId    String @db.Uuid
 
     user User @relation(fields: [userId], references: [id])
 
-    @@unique([id, userId])
+    @@unique([keyId, userId])
     @@index([userId])
     @@map("one_time_pre_keys")
 }

--- a/src/pages/chats.tsx
+++ b/src/pages/chats.tsx
@@ -5,3 +5,8 @@
         ChatList: ChatListHeader, ChatListRow 
         Chat: ChatHeader, ChatMessage, ChatInput
 */
+
+const Placeholder = () => {
+  return <div></div>
+}
+export default Placeholder

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -31,7 +31,6 @@ export default function Login() {
           // toast.error('Log in failed')
           throw new Error(res.error)
         }
-
         reset()
       } catch (err) {
         console.error(err)

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -12,7 +12,7 @@ export const userRouter = createTRPCRouter({
       where: { username },
     })
 
-    return !!userExists
+    return userExists === null
   }),
 
   register: publicProcedure.input(registerWithKeysSchema).mutation(async ({ input, ctx }) => {

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -2,7 +2,7 @@ import { TRPCError } from '@trpc/server'
 import { hash } from 'argon2'
 
 import { createTRPCRouter, publicProcedure } from '~/server/api/trpc'
-import { usernameSchema, registerSchema } from '~/validation/auth'
+import { usernameSchema, registerWithKeysSchema } from '~/validation/auth'
 
 export const userRouter = createTRPCRouter({
   checkUsername: publicProcedure.input(usernameSchema).query(async ({ input, ctx }) => {
@@ -15,8 +15,8 @@ export const userRouter = createTRPCRouter({
     return !!userExists
   }),
 
-  register: publicProcedure.input(registerSchema).mutation(async ({ input, ctx }) => {
-    const { username, password } = input
+  register: publicProcedure.input(registerWithKeysSchema).mutation(async ({ input, ctx }) => {
+    const { username, password, identityPublicKey, signedPreKey, oneTimePreKey } = input
 
     // This redundancy exists to safeguard against client-side attacks
     const userExists = await ctx.prisma.user.findFirst({
@@ -35,9 +35,18 @@ export const userRouter = createTRPCRouter({
     // Further options can be found here: https://github.com/ranisalt/node-argon2/wiki/Options
     const hashedPassword = await hash(password)
 
-    // TODO: add identity key and signed public prekey
     const result = await ctx.prisma.user.create({
-      data: { username, password: hashedPassword },
+      data: {
+        username,
+        password: hashedPassword,
+        identityPublicKey,
+        signedPreKey: {
+          create: signedPreKey,
+        },
+        oneTimePreKeys: {
+          create: oneTimePreKey,
+        },
+      },
     })
 
     return {

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -60,6 +60,7 @@ export const authOptions: NextAuthOptions = {
       authorize: async credentials => {
         try {
           const { username, password } = loginSchema.parse(credentials)
+          console.log(username, password)
 
           const result = await prisma.user.findFirst({
             where: { username },
@@ -89,7 +90,7 @@ export const authOptions: NextAuthOptions = {
       return token
     },
     session({ session, user }) {
-      if (session.user) {
+      if (session.user && user) {
         session.user.id = user.id
         session.user.username = user.username
       }

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -1,0 +1,101 @@
+import type {
+  SignedPublicPreKeyType,
+  PreKeyType,
+  KeyPairType,
+} from '@privacyresearch/libsignal-protocol-typescript'
+import type { PublicUserKeys } from '~/utils/user/types'
+import * as base64 from 'base64-js'
+
+// Note we use base64 over TextEncoder/TextDeocder due to base64's
+// safer encoding of 0's (not string terminating)
+
+// User Key Bundles, to store in DB
+export function serializePublicUserKeys({
+  identityPublicKey,
+  signedPreKey,
+  oneTimePreKey,
+}: PublicUserKeys<ArrayBuffer>): PublicUserKeys<string> {
+  return {
+    identityPublicKey: bufferToString(identityPublicKey),
+    signedPreKey: serializeSignedPreKey(signedPreKey),
+    oneTimePreKey: serializePreKey(oneTimePreKey),
+  }
+}
+
+export function deserializePublicUserKeys({
+  identityPublicKey,
+  signedPreKey,
+  oneTimePreKey,
+}: PublicUserKeys<string>): PublicUserKeys<ArrayBuffer> {
+  return {
+    identityPublicKey: stringToBuffer(identityPublicKey),
+    signedPreKey: deserializeSignedPreKey(signedPreKey),
+    oneTimePreKey: deserializePreKey(oneTimePreKey),
+  }
+}
+
+// PreKeys
+// We don't know if these two are used yet
+// export function serializePreKeyArray(keys: PreKeyType<ArrayBuffer>[]): PreKeyType<string>[] {
+//   return keys.map(serializePreKey)
+// }
+
+// export function deserializePreKeyArray(keys: PreKeyType<string>[]): PreKeyType<ArrayBuffer>[] {
+//   return keys.map(deserializePreKey)
+// }
+
+export function serializeSignedPreKey(
+  key: SignedPublicPreKeyType<ArrayBuffer>
+): SignedPublicPreKeyType<string> {
+  return {
+    ...serializePreKey(key),
+    signature: bufferToString(key.signature),
+  }
+}
+
+export function deserializeSignedPreKey(
+  key: SignedPublicPreKeyType<string>
+): SignedPublicPreKeyType<ArrayBuffer> {
+  return {
+    ...deserializePreKey(key),
+    signature: stringToBuffer(key.signature),
+  }
+}
+
+export function serializePreKey(key: PreKeyType<ArrayBuffer>): PreKeyType<string> {
+  return {
+    keyId: key.keyId,
+    publicKey: bufferToString(key.publicKey),
+  }
+}
+
+export function deserializePreKey(key: PreKeyType<string>): PreKeyType<ArrayBuffer> {
+  return {
+    keyId: key.keyId,
+    publicKey: stringToBuffer(key.publicKey),
+  }
+}
+
+// Key Pairs
+export function serializeKeyPair(key: KeyPairType<ArrayBuffer>): KeyPairType<string> {
+  return {
+    pubKey: bufferToString(key.pubKey),
+    privKey: bufferToString(key.privKey),
+  }
+}
+
+export function deserializeKeyPair(key: KeyPairType<string>): KeyPairType<ArrayBuffer> {
+  return {
+    pubKey: stringToBuffer(key.pubKey),
+    privKey: stringToBuffer(key.privKey),
+  }
+}
+
+// Buffer/String conversions
+function bufferToString(buffer: ArrayBuffer): string {
+  return base64.fromByteArray(new Uint8Array(buffer))
+}
+
+function stringToBuffer(str: string): ArrayBuffer {
+  return base64.toByteArray(str).buffer
+}

--- a/src/utils/user/types.ts
+++ b/src/utils/user/types.ts
@@ -1,0 +1,19 @@
+import type {
+  KeyPairType,
+  PreKeyPairType,
+  PreKeyType,
+  SignedPreKeyPairType,
+  SignedPublicPreKeyType,
+} from '@privacyresearch/libsignal-protocol-typescript'
+
+export type UserKeys<T = ArrayBuffer> = {
+  identityKeyPair: KeyPairType<T>
+  signedPreKey: SignedPreKeyPairType<T>
+  oneTimePreKey: PreKeyPairType<T>
+}
+
+export type PublicUserKeys<T = ArrayBuffer> = {
+  identityPublicKey: T
+  signedPreKey: SignedPublicPreKeyType<T>
+  oneTimePreKey: PreKeyType<T>
+}

--- a/src/utils/user/user-keys.ts
+++ b/src/utils/user/user-keys.ts
@@ -12,10 +12,10 @@ export async function createNewUserKeys() {
   const identityKeyPair = await KeyHelper.generateIdentityKeyPair()
 
   // TODO: make key ids collision resistant
-  const signedPreKeyId = Math.floor(10e8 * Math.random())
+  const signedPreKeyId = Math.floor(10e4 * Math.random())
   const signedPreKey = await KeyHelper.generateSignedPreKey(identityKeyPair, signedPreKeyId)
 
-  const oneTimePreKeyId = Math.floor(10e8 * Math.random())
+  const oneTimePreKeyId = Math.floor(10e4 * Math.random())
   const oneTimePreKey = await KeyHelper.generatePreKey(oneTimePreKeyId)
 
   return {

--- a/src/utils/user/user-keys.ts
+++ b/src/utils/user/user-keys.ts
@@ -1,0 +1,48 @@
+import { KeyHelper } from '@privacyresearch/libsignal-protocol-typescript'
+import type { UserKeys, PublicUserKeys } from './types'
+
+/**
+ * Creates a new set of user keys via libsignal's KeyHelper
+ */
+export async function createNewUserKeys() {
+  // Registration ID is a number identifies the user, can be same as userId
+  // A DB-based registration/user id is better, as it can enforce the constraint
+  // const registrationId = KeyHelper.generateRegistrationId()
+
+  const identityKeyPair = await KeyHelper.generateIdentityKeyPair()
+
+  // TODO: make key ids collision resistant
+  const signedPreKeyId = Math.floor(10e8 * Math.random())
+  const signedPreKey = await KeyHelper.generateSignedPreKey(identityKeyPair, signedPreKeyId)
+
+  const oneTimePreKeyId = Math.floor(10e8 * Math.random())
+  const oneTimePreKey = await KeyHelper.generatePreKey(oneTimePreKeyId)
+
+  return {
+    identityKeyPair,
+    signedPreKey,
+    oneTimePreKey,
+  } satisfies UserKeys
+}
+
+/**
+ * Extracts the public keys from a UserKeys object for DB entry
+ */
+export function extractPublicUserKeys({
+  identityKeyPair,
+  signedPreKey,
+  oneTimePreKey,
+}: UserKeys): PublicUserKeys {
+  return {
+    identityPublicKey: identityKeyPair.pubKey,
+    signedPreKey: {
+      keyId: signedPreKey.keyId,
+      publicKey: signedPreKey.keyPair.pubKey,
+      signature: signedPreKey.signature,
+    },
+    oneTimePreKey: {
+      keyId: oneTimePreKey.keyId,
+      publicKey: oneTimePreKey.keyPair.pubKey,
+    },
+  }
+}

--- a/src/utils/user/user-keys.ts
+++ b/src/utils/user/user-keys.ts
@@ -5,18 +5,13 @@ import type { UserKeys, PublicUserKeys } from './types'
  * Creates a new set of user keys via libsignal's KeyHelper
  */
 export async function createNewUserKeys() {
-  // Registration ID is a number identifies the user, can be same as userId
-  // A DB-based registration/user id is better, as it can enforce the constraint
-  // const registrationId = KeyHelper.generateRegistrationId()
-
   const identityKeyPair = await KeyHelper.generateIdentityKeyPair()
 
-  // TODO: make key ids collision resistant
-  const signedPreKeyId = Math.floor(10e4 * Math.random())
-  const signedPreKey = await KeyHelper.generateSignedPreKey(identityKeyPair, signedPreKeyId)
+  const keyIds = crypto.getRandomValues(new Uint16Array(2))
 
-  const oneTimePreKeyId = Math.floor(10e4 * Math.random())
-  const oneTimePreKey = await KeyHelper.generatePreKey(oneTimePreKeyId)
+  const signedPreKey = await KeyHelper.generateSignedPreKey(identityKeyPair, keyIds[0]!)
+
+  const oneTimePreKey = await KeyHelper.generatePreKey(keyIds[1]!)
 
   return {
     identityKeyPair,

--- a/src/validation/auth.ts
+++ b/src/validation/auth.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { identityPublicKeySchema, preKeySchema, signedPreKeySchema } from './keys'
 
 // Client-side error handling/validation done here, server-side is done via the TRPC router
 export const usernameSchema = z.object({
@@ -18,18 +19,27 @@ export const loginSchema = usernameSchema.extend({
     .max(64, 'Password must be at most 64 characters'),
 })
 
-export const registerSchema = loginSchema
-  .extend({
-    confirmPassword: z.string().nonempty('Password confirmation is required'),
-    // terms & conditions to be added later
-    // terms: z.literal(true, {
-    // errorMap: () => ({ message: "You must accept the terms and conditions" }),
-    // }),
-  })
-  .refine(({ password, confirmPassword }) => password === confirmPassword, {
+export const registerSchema = loginSchema.extend({
+  confirmPassword: z.string().nonempty('Password confirmation is required'),
+  // terms & conditions to be added later
+  // terms: z.literal(true, {
+  // errorMap: () => ({ message: "You must accept the terms and conditions" }),
+  // }),
+})
+
+export const registerWithPWMatchSchema = registerSchema.refine(
+  ({ password, confirmPassword }) => password === confirmPassword,
+  {
     path: ['confirmPassword'],
     message: 'Passwords do not match',
-  })
+  }
+)
+
+export const registerWithKeysSchema = registerSchema.extend({
+  identityPublicKey: identityPublicKeySchema,
+  signedPreKey: signedPreKeySchema,
+  oneTimePreKey: preKeySchema,
+})
 
 export type ILogin = z.infer<typeof loginSchema>
 export type IRegister = z.infer<typeof registerSchema>

--- a/src/validation/keys.ts
+++ b/src/validation/keys.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+// Zod schemas for serialized user keys
+export const identityPublicKeySchema = z.string().nonempty()
+
+export const preKeySchema = z.object({
+  keyId: z.number(),
+  publicKey: z.string().nonempty(),
+})
+
+export const signedPreKeySchema = preKeySchema.extend({
+  signature: z.string().nonempty(),
+})


### PR DESCRIPTION
### Changes from original
- Typing - make use of generics and reduce redundancies, eliminates the need for `utility/serialize/FullDirectoryEntry.ts` 
- Took off array of one-time prekeys until their usage is more understood and documented (current implementation doesn't seem to really use it, Signal's demo also doesn't, and the typing `DeviceType` from libsignal seems to imply similar)
- Took off `registrationId` - seems to be a replacement for `userId`, but its low ceiling (14 bits of entropy), poor collision handling (separately tested), and lack of use (demo doesn't use it at all) demanded it not be used at all
- Separated concerns to maintain FP principles - we want to ensure maintainability
- Fixed naming conventions for better readability (for ex, username often switched back and forth between `name`, `address`, `directory`, and `directoryName`)
- Check username before generating keys (i.e., we only generate keys once we're sure that the user will be created), avoid unnecessary storage

### Issues: 
- dependency error from libsignal's curve25519 package due to `fs` - currently is a non-blocking issue, but it's worth noting that because it's run client side, some functions of libsignal are not available
- others noted in the [TODO doc](https://docs.google.com/document/d/1xkEjUk1OGu7EDTuFgsQdng0edvVlgXXPYpEoa1X1ot4/edit#)

**Next step**: add storage (maybe persist through global state, eyeing Zustand atm) - to be done after mutation success. In storage, keys (as in the key/value pairs) must be associated with the user somehow s.t. other users are able to log in (localStorage should _not_ clear on every new user). 
