### PR TITLE
Added collision resistant key id generation via CSPRNG

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,7 @@ const config = {
       },
     ],
     '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: false }],
+    '@typescript-eslint/no-non-null-assertion': 'off',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'error',
     'no-var': 'error',

--- a/src/utils/user/user-keys.ts
+++ b/src/utils/user/user-keys.ts
@@ -7,12 +7,11 @@ import type { UserKeys, PublicUserKeys } from './types'
 export async function createNewUserKeys() {
   const identityKeyPair = await KeyHelper.generateIdentityKeyPair()
 
-  const keyIds = crypto.getRandomValues(new Uint32Array(2))
+  const keyIds = crypto.getRandomValues(new Uint16Array(2))
 
   const signedPreKey = await KeyHelper.generateSignedPreKey(identityKeyPair, keyIds[0]!)
 
   const oneTimePreKey = await KeyHelper.generatePreKey(keyIds[1]!)
-
 
   return {
     identityKeyPair,

--- a/src/utils/user/user-keys.ts
+++ b/src/utils/user/user-keys.ts
@@ -5,18 +5,13 @@ import type { UserKeys, PublicUserKeys } from './types'
  * Creates a new set of user keys via libsignal's KeyHelper
  */
 export async function createNewUserKeys() {
-  // Registration ID is a number identifies the user, can be same as userId
-  // A DB-based registration/user id is better, as it can enforce the constraint
-  // const registrationId = KeyHelper.generateRegistrationId()
-
   const identityKeyPair = await KeyHelper.generateIdentityKeyPair()
 
-  // TODO: make key ids collision resistant
-  const signedPreKeyId = Math.floor(10e8 * Math.random())
-  const signedPreKey = await KeyHelper.generateSignedPreKey(identityKeyPair, signedPreKeyId)
+  const keyIds = crypto.getRandomValues(new Uint32Array(2))
 
-  const oneTimePreKeyId = Math.floor(10e8 * Math.random())
-  const oneTimePreKey = await KeyHelper.generatePreKey(oneTimePreKeyId)
+  const signedPreKey = await KeyHelper.generateSignedPreKey(identityKeyPair, keyIds[0]!)
+
+  const oneTimePreKey = await KeyHelper.generatePreKey(keyIds[1]!)
 
   return {
     identityKeyPair,


### PR DESCRIPTION
Previously key ids were generated via `Math.random` - this is fine if we're circulating our store s.t. keys are not reused. However, this does introduce an issue where if multiple keys are active at once (say, if we store multiple users' keys via the same local storage key hash), they could be overwritten (and permanently lost). 

However, this does introduce a secondary problem of space - i.e., if the allowed table size (in this case, $2^{32}$) is too large, local storage could be overwhelmed. Can be fixed using a smaller sized integer (e.g., `Uint16`) while still maintaining collision resistance compared to `Math.random` PRNG. In that case, 16 bits of entropy would give us a similar amount of space as the original (~14 bits).

Proof of concept, not to be merged until we get further answers on above issues. 